### PR TITLE
Add httpOnly and secure flags to cookies

### DIFF
--- a/src/releaseManager.ts
+++ b/src/releaseManager.ts
@@ -40,6 +40,8 @@ server.use(async (req, res) => {
     if (env) {
       res.cookie(branchPreviewCookieName, env.name, {
         maxAge: 2 * 60 * 60 * 1000,
+        httpOnly: true,
+        secure: true,
       });
     } else {
       res.clearCookie(branchPreviewCookieName);
@@ -52,6 +54,8 @@ server.use(async (req, res) => {
     );
     res.cookie(trafficSplittingCookieName, env.name, {
       maxAge: 24 * 60 * 60 * 1000,
+      httpOnly: true,
+      secure: true,
     });
   }
 


### PR DESCRIPTION
Quoting from [ASafaWeb report](https://asafaweb.com/Scan?Url=https%3A%2F%2Fhollowverse.com%2FTom_Hanks%3Fbranch%3Dnew-app#SecureCookiesResult):

> Cookies not flagged as "HttpOnly" may be read by client side script and are at risk of being interpreted by a cross site scripting (XSS) attack. Whilst there are times where a cookie set by the server may be legitimately read by client script, most times the "HttpOnly" flag is missing it is due to oversight rather than by design.

> Cookies served over HTTPS but not flagged as "secure" may be sent over an insecure connection by the browser. Often this may be a simple request for an asset such as a bitmap file but if it's on the same domain as the cookie is valid for then it will be sent in an insecure fashion. This poses a risk of interception via a man in the middle attack.

