### PR TITLE
Fix filename validation

### DIFF
--- a/commonconfig.js
+++ b/commonconfig.js
@@ -1,6 +1,10 @@
 module.exports = {
   rules: [
     {
+      validation: 'camelCase',
+      patterns: ['**/*'],
+    },
+    {
       validation: 'ignore',
       patterns: [
         '*/**/typings/*',


### PR DESCRIPTION
`camelCase` validation was missing in `commonconfig.js`.