### PR TITLE
Clear branch cookie when a public environment is served

### DIFF
--- a/src/releaseManager.ts
+++ b/src/releaseManager.ts
@@ -43,8 +43,6 @@ server.use(async (req, res) => {
         httpOnly: true,
         secure: true,
       });
-    } else {
-      res.clearCookie(branchPreviewCookieName);
     }
   }
 
@@ -53,6 +51,9 @@ server.use(async (req, res) => {
       req.cookies[trafficSplittingCookieName],
       req.header('user-agent'),
     );
+
+    res.clearCookie(branchPreviewCookieName);
+
     res.cookie(trafficSplittingCookieName, env.name, {
       maxAge: 24 * 60 * 60 * 1000,
       httpOnly: true,

--- a/src/trafficSplitter/getEnvForTrafficSplitting.ts
+++ b/src/trafficSplitter/getEnvForTrafficSplitting.ts
@@ -32,6 +32,7 @@ const getEnvForTrafficSplitting = async (
   // if the environment is defined but does not have a URL
   envUrl = map.get(envName);
   if (!envUrl) {
+    envName = defaultEnvName;
     envUrl = map.get(defaultEnvName) as string;
   }
 


### PR DESCRIPTION
With regard to hollowverse/hollowverse#287, I think what is happening is that the very first request for the HTML markup is being sent without the `branch` cookie for one reason or the other, so it's routed to either `master` or `beta`, while subsequent requests for stylesheets and scripts do have the `branch` cookie and are being routed to `new-app`. This means that the browser is receiving the HTML markup which references stylesheets and scripts of a public environment, but these assets are being requested from the `new-app` branch, which does not have them.

This PR moves the call to `clearCookie(branchPreviewCookieName)` to the code branch where we prepare to serve a public environment, so that we ensure that the subsequent requests will have the `branch` cookie cleared.