### PR TITLE
Set changeOrigin and toProxy options to true in proxy settings

### DIFF
--- a/src/releaseManager.ts
+++ b/src/releaseManager.ts
@@ -97,7 +97,8 @@ server.use(async (req, res) => {
   proxyServer.web(req, res, {
     // tslint:disable-next-line:no-http-string
     target: `https://${env.url}`,
-    changeOrigin: false,
+    changeOrigin: true,
+    toProxy: true,
 
     // If set to `true`, the process will crash when validating the certificate
     // of the environment endpoint, because that endpoint currently has a certificate


### PR DESCRIPTION
I'm getting "Too Many Redirects" after I put Cloudfront in front of release manager on thehollowverse.com.

Honestly, I'm not sure what's going on, but if I understand correctly, if `changeOrigin` is not set to `true`, the request will not have a `Host` header, and Cloudfront might be setting it back to the CF host.

I'll revert this if it causes any issues on hollowverse.com