### PR TITLE
Tell Cloudfront not to cache internal branches or requests without an environment

### DIFF
--- a/src/releaseManager.ts
+++ b/src/releaseManager.ts
@@ -65,7 +65,7 @@ proxyServer.on('proxyRes', (_, req, res) => {
       // The `s-` prefix stands for "shared" and is only respected by
       // CDNs. Browsers will use the standard `max-age` directive.
       // tslint:disable-next-line:no-backbone-get-set-outside-model
-      res.setHeader('Cache-Control', 's-max-age=0');
+      res.setHeader('Cache-Control', 's-max-age=0, proxy-revalidate');
     }
   }
 });

--- a/src/releaseManager.ts
+++ b/src/releaseManager.ts
@@ -42,8 +42,8 @@ const trafficSplittingCookieName = 'env';
 const branchPreviewCookieName = 'branch';
 
 type Context = {
-  requestedBranchName?: string;
-  requestedEnvironmentName?: string;
+  readonly requestedBranchName?: string;
+  readonly requestedEnvironmentName?: string;
 };
 
 type RequestWithContext = IncomingMessage & { context: Context };

--- a/src/releaseManager.ts
+++ b/src/releaseManager.ts
@@ -64,8 +64,19 @@ proxyServer.on('proxyRes', (_, req, res) => {
 
       // The `s-` prefix stands for "shared" and is only respected by
       // CDNs. Browsers will use the standard `max-age` directive.
-      // tslint:disable-next-line:no-backbone-get-set-outside-model
-      res.setHeader('Cache-Control', 's-max-age=0, proxy-revalidate');
+      let header = res.getHeader('Cache-Control');
+      if (!header) {
+        res.setHeader('Cache-Control', 's-max-age=0, proxy-revalidate');
+      } else {
+        if (Array.isArray(header)) {
+          header = header[0];
+        }
+
+        res.setHeader(
+          'Cache-Control',
+          `${header}, s-max-age=0, proxy-revalidate`,
+        );
+      }
     }
   }
 });


### PR DESCRIPTION
We want requests to internal branches to be live. We also want requests from users that were not assigned an environment to be forwarded to the origin server in order to get an environment assigned to them.

If this works, we might not need to use Lambda@Edge.